### PR TITLE
Correct typo of throttler in error message and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ To start in developing mode:
 
 * [HTTP API Doc](https://github.com/bitleak/lmstfy/blob/master/doc/API.md)
 * [Administration API Doc](https://github.com/bitleak/lmstfy/blob/master/doc/administration.en.md)
-* [Throtter API Doc](https://github.com/bitleak/lmstfy/blob/master/doc/throtter.en.md)
+* [Throttler API Doc](https://github.com/bitleak/lmstfy/blob/master/doc/throttler.en.md)
 * [Pusher API Doc](https://github.com/bitleak/lmstfy/blob/master/doc/pusher.en.md)
 * [管理 API 中文文档](https://github.com/bitleak/lmstfy/blob/master/doc/administration.cn.md)
-* [限流 API 中文文档](https://github.com/bitleak/lmstfy/blob/master/doc/throtter.cn.md)
+* [限流 API 中文文档](https://github.com/bitleak/lmstfy/blob/master/doc/throttler.cn.md)
 * [推送 API 中文文档](https://github.com/bitleak/lmstfy/blob/master/doc/pusher.cn.md)
 
 ---

--- a/throttler/throttler.go
+++ b/throttler/throttler.go
@@ -139,13 +139,13 @@ func (t *Throttler) IsReachRateLimit(pool, namespace, token string, isRead bool)
 	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT") {
 		sha, err := t.redisCli.ScriptLoad(throttleIncrLuaScript).Result()
 		if err != nil {
-			return true, fmt.Errorf("failed to load the throtter incr script err: %s", err.Error())
+			return true, fmt.Errorf("failed to load the throttler incr script err: %s", err.Error())
 		}
 		t.incrSHA = sha
 		val, err = t.redisCli.EvalSha(t.incrSHA, []string{tokenCounterKey}, limiter.Interval).Result()
 	}
 	if err != nil {
-		return true, fmt.Errorf("failed to eval the throtter incr script err: %s", err.Error())
+		return true, fmt.Errorf("failed to eval the throttler incr script err: %s", err.Error())
 	}
 	if isRead {
 		return val.(int64) > limiter.Read, nil


### PR DESCRIPTION
BUT this variable/package should be named as 'Throttle' exactly.