### PR TITLE
FIX: `bt_func` and `bt_line` was went wrong after upgrading the vendor to mod

### DIFF
--- a/log/backtrack.go
+++ b/log/backtrack.go
@@ -24,7 +24,7 @@ func (bt *BackTrackHook) Levels() []logrus.Level {
 
 func (bt *BackTrackHook) Fire(entry *logrus.Entry) error {
 	pcs := make([]uintptr, 5)
-	n := runtime.Callers(4, pcs)
+	n := runtime.Callers(8, pcs)
 	if n == 0 {
 		return nil
 	}
@@ -34,7 +34,7 @@ func (bt *BackTrackHook) Fire(entry *logrus.Entry) error {
 	funcName := "unknown"
 	for {
 		frame, more := frames.Next()
-		if strings.Index(frame.Function, "vendor") == -1 {
+		if strings.Index(frame.Function, "github.com/sirupsen/logrus") == -1 {
 			// This if the frame we are looking for
 			file = frame.File
 			line = frame.Line

--- a/log/backtrack_test.go
+++ b/log/backtrack_test.go
@@ -1,10 +1,31 @@
 package log
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
+
+func TestFire(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logrus.New()
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetOutput(&buf)
+	logger.Hooks.Add(NewBackTrackHook(logrus.DebugLevel))
+	logger.SetLevel(logrus.DebugLevel)
+	logger.Error("test backtrace")
+	entry := make(map[string]string)
+	json.Unmarshal(buf.Bytes(), &entry)
+	if !strings.HasSuffix(entry["bt_func"], "TestFire") {
+		t.Fatal("bt_func suffix should be TestFunc was expected")
+	}
+	if !strings.Contains(entry["bt_line"], "backtrack_test.go") {
+		t.Fatal("bt_func suffix contains backtrack_test.go was expected")
+	}
+}
 
 func TestBackTrackFormatter(t *testing.T) {
 	logger := logrus.New()


### PR DESCRIPTION
the logrus backtrace hook using the `vendor` keyword to anti-search the user function and file line, it was broken after upgrading the vendor to the go mod.  