### PR TITLE
Add go 1.16 to Github Action

### DIFF
--- a/.github/workflows/lmstfy.yaml
+++ b/.github/workflows/lmstfy.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Lint/Build/Test 
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
- Add Go version 1.16.x to github action
- Make linting pass in Go 1.16.x

`t.Fatalf` in a new goroutine is not a good idea

`t.Fatalf` = log + `FailNow`

https://golang.org/pkg/testing/#T.FailNow