### PR TITLE
Auto respawn lost jobs in backup

### DIFF
--- a/engine/redis_v2/deadletter_test.go
+++ b/engine/redis_v2/deadletter_test.go
@@ -75,7 +75,7 @@ func TestDeadLetter_Respawn(t *testing.T) {
 		t.Fatalf("Respawned job's TTL should be removed")
 	}
 
-	timer, err := NewTimer("ns-dead", R, time.Second)
+	timer, err := NewTimer("ns-dead", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}

--- a/engine/redis_v2/engine.go
+++ b/engine/redis_v2/engine.go
@@ -42,7 +42,7 @@ func NewEngine(redisName string, conn *go_redis.Client) (engine.Engine, error) {
 	}
 	go RedisInstanceMonitor(redis)
 	meta := NewMetaManager(redis)
-	timer, err := NewTimer("timer_set_v2", redis, time.Second)
+	timer, err := NewTimer("timer_set_v2", redis, time.Second, 600*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/redis_v2/queue_test.go
+++ b/engine/redis_v2/queue_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestQueue_Push(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -30,7 +30,7 @@ func TestQueue_Push(t *testing.T) {
 }
 
 func TestQueue_Poll(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -51,7 +51,7 @@ func TestQueue_Poll(t *testing.T) {
 }
 
 func TestQueue_Peek(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -69,7 +69,7 @@ func TestQueue_Peek(t *testing.T) {
 }
 
 func TestQueue_Destroy(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -91,7 +91,7 @@ func TestQueue_Destroy(t *testing.T) {
 }
 
 func TestQueue_Tries(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -140,7 +140,7 @@ func TestStructPacking(t *testing.T) {
 }
 
 func TestPopMultiQueues(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_q", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -189,7 +189,7 @@ func TestPopMultiQueues(t *testing.T) {
 }
 
 func TestQueue_Backup(t *testing.T) {
-	timer, err := NewTimer("timer_set_for_test_backup", R, time.Second)
+	timer, err := NewTimer("timer_set_for_test_backup", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}

--- a/engine/redis_v2/queue_test.go
+++ b/engine/redis_v2/queue_test.go
@@ -209,7 +209,7 @@ func TestQueue_Backup(t *testing.T) {
 		pool := NewPool(R)
 		pool.Add(job)
 	}
-	backupName := timer.getBackupName()
+	backupName := timer.BackupName()
 	memberScores, err := q.redis.Conn.ZRangeWithScores(dummyCtx, backupName, 0, -1).Result()
 	assert.Nil(t, err)
 	now := time.Now().Unix()

--- a/engine/redis_v2/queue_test.go
+++ b/engine/redis_v2/queue_test.go
@@ -189,7 +189,7 @@ func TestPopMultiQueues(t *testing.T) {
 }
 
 func TestQueue_Backup(t *testing.T) {
-	timer, err := NewTimer("timer_set_q", R, time.Second)
+	timer, err := NewTimer("timer_set_for_test_backup", R, time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -209,12 +209,16 @@ func TestQueue_Backup(t *testing.T) {
 		pool := NewPool(R)
 		pool.Add(job)
 	}
-	backupQueueName := timer.BuildBackupKey(namespace, queue)
-	memberScores, err := q.redis.Conn.ZRangeWithScores(dummyCtx, backupQueueName, 0, -1).Result()
+	backupName := timer.getBackupName()
+	memberScores, err := q.redis.Conn.ZRangeWithScores(dummyCtx, backupName, 0, -1).Result()
 	assert.Nil(t, err)
 	now := time.Now().Unix()
 	for _, memberScore := range memberScores {
-		assert.Equal(t, 26, len(memberScore.Member.(string)))
+		gotNamespace, gotQueue, gotJobID, err := structUnpackTimerData([]byte(memberScore.Member.(string)))
+		assert.Nil(t, err)
+		assert.Equal(t, namespace, gotNamespace)
+		assert.Equal(t, queue, gotQueue)
+		assert.Equal(t, 26, len(gotJobID))
 		timestamp, tries := decodeScore(memberScore.Score)
 		assert.Equal(t, uint16(2), tries)
 		assert.LessOrEqual(t, timestamp, now)
@@ -226,7 +230,7 @@ func TestQueue_Backup(t *testing.T) {
 			t.Fatalf("Failed to poll job from queue: %s", err)
 		}
 	}
-	backupCount, err := q.redis.Conn.ZCard(dummyCtx, backupQueueName).Result()
+	backupCount, err := q.redis.Conn.ZCard(dummyCtx, backupName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), backupCount)
 }

--- a/engine/redis_v2/timer.go
+++ b/engine/redis_v2/timer.go
@@ -128,12 +128,12 @@ type Timer struct {
 }
 
 // NewTimer return an instance of delay queue
-func NewTimer(name string, redis *RedisInstance, interval time.Duration) (*Timer, error) {
+func NewTimer(name string, redis *RedisInstance, interval, checkBackupInterval time.Duration) (*Timer, error) {
 	timer := &Timer{
 		name:                name,
 		redis:               redis,
 		interval:            interval,
-		checkBackupInterval: interval * 600,
+		checkBackupInterval: checkBackupInterval,
 		shutdown:            make(chan struct{}),
 	}
 

--- a/engine/redis_v2/timer.go
+++ b/engine/redis_v2/timer.go
@@ -11,15 +11,75 @@ import (
 )
 
 const (
+	luaPumpBackupScript = `
+local zset_key = KEYS[1]
+local queue_prefix = KEYS[2]
+local pool_prefix = KEYS[3]
+local new_score = tonumber(ARGV[1])
+local max_score = ARGV[2]
+local limit = ARGV[3]
+local backup_key = table.concat({zset_key, "backup"}, "/")
+
+local memberScores = redis.call("ZRANGEBYSCORE", backup_key, 0, max_score, "WITHSCORES", "LIMIT", 0, limit)
+
+if #memberScores == 0 then
+	return 0
+end
+
+local toBeRemovedMembers = {}
+for i = 1, #memberScores, 2 do
+	local member = memberScores[i]
+	local score = tonumber(memberScores[i+1])
+	local ns, q, job_id = struct.unpack("Hc0Hc0Hc0", member)
+	local need_next_check = true
+	-- ignore jobs which are expired or ACKed
+	if redis.call("EXISTS", table.concat({pool_prefix, ns, q, job_id}, "/")) == 0 then
+		-- the job was expired or acked, just discard it
+		table.insert(toBeRemovedMembers, member)
+		need_next_check = false
+	end
+
+	local oldest_elem = nil
+	if need_next_check then
+		oldest_elem = redis.call("LINDEX", table.concat({queue_prefix, ns, q}, "/"), "-1")
+		if not oldest_elem then
+			-- no elem in the queue means those queue jobs in backup are lost,
+			-- since consumer can't fetch them.
+			table.insert(toBeRemovedMembers, member)
+			redis.call("ZADD", zset_key, score, member)
+			need_next_check = false
+		end
+	end
+
+	if need_next_check then
+		-- the score in backup is updated by queuing time, so it means those jobs
+		-- should be consumed since they are older than first element in ready queue
+		local tries, oldest_job_id = struct.unpack("HHc0", oldest_elem)
+		local oldest_member = struct.pack("Hc0Hc0Hc0", #ns, ns, #q, q, #oldest_job_id, oldest_job_id)
+		local oldest_score = redis.call("ZSCORE", backup_key, oldest_member)
+		if oldest_score and tonumber(oldest_score) > score then
+			table.insert(toBeRemovedMembers, member)
+			local tries = bit.band(score, 0xffff)
+			redis.call("ZADD", zset_key, new_score+tries, member)
+		end
+	end
+end
+
+if #toBeRemovedMembers > 0 then
+	redis.call("ZREM", backup_key, unpack(toBeRemovedMembers))
+end
+return #toBeRemovedMembers
+`
 	luaPumpQueueScript = `
 local zset_key = KEYS[1]
 local output_queue_prefix = KEYS[2]
 local pool_prefix = KEYS[3]
 local output_deadletter_prefix = KEYS[4]
-local min_score= ARGV[1]
+local max_score= ARGV[1]
 local limit = ARGV[2]
 
-local expiredMembers = redis.call("ZRANGEBYSCORE", zset_key, 0, min_score, "WITHSCORES", "LIMIT", 0, limit)
+local backup_key = table.concat({zset_key, "backup"}, "/")
+local expiredMembers = redis.call("ZRANGEBYSCORE", zset_key, 0, max_score, "WITHSCORES", "LIMIT", 0, limit)
 
 if #expiredMembers == 0 then
 	return 0
@@ -45,7 +105,6 @@ for i = 1, #expiredMembers, 2 do
 			-- move to ready queue
 			local val = struct.pack("HHc0", tonumber(tries), #job_id, job_id)
 			redis.call("LPUSH", table.concat({output_queue_prefix, ns, q}, "/"), val)
-			local backup_key = table.concat({zset_key, "backup"}, "/")
 			redis.call("ZADD", backup_key, score, v)
 		end
 	end
@@ -58,21 +117,24 @@ return #toBeRemovedMembers
 // Timer is the other way of saying "delay queue". timer kick jobs into ready queue when
 // it's ready.
 type Timer struct {
-	name     string
-	redis    *RedisInstance
-	interval time.Duration
-	shutdown chan struct{}
+	name                string
+	redis               *RedisInstance
+	interval            time.Duration
+	checkBackupInterval time.Duration
+	shutdown            chan struct{}
 
-	pumpSHA string
+	pumpSHA       string
+	pumpBackupSHA string
 }
 
 // NewTimer return an instance of delay queue
 func NewTimer(name string, redis *RedisInstance, interval time.Duration) (*Timer, error) {
 	timer := &Timer{
-		name:     name,
-		redis:    redis,
-		interval: interval,
-		shutdown: make(chan struct{}),
+		name:                name,
+		redis:               redis,
+		interval:            interval,
+		checkBackupInterval: interval * 600,
+		shutdown:            make(chan struct{}),
 	}
 
 	// Preload the lua scripts
@@ -82,6 +144,13 @@ func NewTimer(name string, redis *RedisInstance, interval time.Duration) (*Timer
 		return nil, err
 	}
 	timer.pumpSHA = sha
+
+	backupSHA, err := redis.Conn.ScriptLoad(dummyCtx, luaPumpBackupScript).Result()
+	if err != nil {
+		logger.WithField("err", err).Error("Failed to preload lua script in timer")
+		return nil, err
+	}
+	timer.pumpBackupSHA = backupSHA
 
 	go timer.tick()
 	return timer, nil
@@ -153,40 +222,82 @@ func (t *Timer) Add(namespace, queue, jobID string, delaySecond uint32, tries ui
 	return nil
 }
 
-func (t *Timer) getBackupName() string {
+func (t *Timer) BackupName() string {
 	return strings.Join([]string{t.Name(), "backup"}, "/")
 }
 
 func (t *Timer) addToBackup(namespace, queue, jobID string, tries uint16) error {
 	score := encodeScore(time.Now().Unix(), tries)
 	member := structPackTimerData(namespace, queue, jobID)
-	return t.redis.Conn.ZAdd(dummyCtx, t.getBackupName(), &redis.Z{Score: score, Member: member}).Err()
+	return t.redis.Conn.ZAdd(dummyCtx, t.BackupName(), &redis.Z{Score: score, Member: member}).Err()
 }
 
 func (t *Timer) removeFromBackup(namespace, queue, jobID string) error {
 	member := structPackTimerData(namespace, queue, jobID)
 	metrics.timerRemoveBackupJobs.WithLabelValues(t.redis.Name).Inc()
-	return t.redis.Conn.ZRem(dummyCtx, t.getBackupName(), member).Err()
+	return t.redis.Conn.ZRem(dummyCtx, t.BackupName(), member).Err()
 }
 
 // Tick pump all due jobs to the target queue
 func (t *Timer) tick() {
 	tick := time.NewTicker(t.interval)
+	checkBackupTicker := time.NewTicker(t.checkBackupInterval)
 	for {
 		select {
 		case now := <-tick.C:
 			currentSecond := now.Unix()
 			t.pump(currentSecond)
+		case now := <-checkBackupTicker.C:
+			t.pumpBackup(now.Unix())
 		case <-t.shutdown:
 			return
 		}
 	}
 }
 
+func (t *Timer) pumpBackup(currentSecond int64) {
+	maxScore := encodeScore(currentSecond-int64(t.checkBackupInterval.Seconds()), math.MaxUint16)
+	newScore := encodeScore(currentSecond, 0)
+	val, err := t.redis.Conn.EvalSha(dummyCtx, t.pumpBackupSHA,
+		[]string{t.Name(), QueuePrefix, PoolPrefix},
+		newScore, maxScore, BatchSize,
+	).Result()
+
+	if err != nil {
+		if isLuaScriptGone(err) { // when redis restart, the script needs to be uploaded again
+			sha, err := t.redis.Conn.ScriptLoad(dummyCtx, luaPumpBackupScript).Result()
+			if err != nil {
+				logger.WithField("err", err).Error("Failed to reload script")
+				time.Sleep(time.Second)
+				return
+			}
+			t.pumpBackupSHA = sha
+		}
+		logger.WithField("err", err).Error("Failed to pump")
+
+		val, err = t.redis.Conn.EvalSha(dummyCtx, t.pumpBackupSHA,
+			[]string{t.Name(), QueuePrefix, PoolPrefix},
+			newScore, maxScore, BatchSize,
+		).Result()
+		if err != nil {
+			logger.WithField("err", err).Error("Failed to pump")
+			return
+		}
+	}
+	n, _ := val.(int64)
+	if n > 0 {
+		logger.WithField("count", n).Warn("Find lost jobs")
+	}
+}
+
 func (t *Timer) pump(currentSecond int64) {
-	minScore := encodeScore(currentSecond, math.MaxUint16)
+	maxScore := encodeScore(currentSecond, math.MaxUint16)
 	for {
-		val, err := t.redis.Conn.EvalSha(dummyCtx, t.pumpSHA, []string{t.Name(), QueuePrefix, PoolPrefix, DeadLetterPrefix}, minScore, BatchSize).Result()
+		val, err := t.redis.Conn.EvalSha(dummyCtx, t.pumpSHA,
+			[]string{t.Name(), QueuePrefix, PoolPrefix, DeadLetterPrefix},
+			maxScore, BatchSize,
+		).Result()
+
 		if err != nil {
 			if isLuaScriptGone(err) { // when redis restart, the script needs to be uploaded again
 				sha, err := t.redis.Conn.ScriptLoad(dummyCtx, luaPumpQueueScript).Result()

--- a/engine/redis_v2/timer_test.go
+++ b/engine/redis_v2/timer_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTimer_Add(t *testing.T) {
-	timer, err := NewTimer("timer_set_1", R, time.Second)
+	timer, err := NewTimer("timer_set_1", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -24,7 +24,7 @@ func TestTimer_Add(t *testing.T) {
 }
 
 func TestTimer_Tick(t *testing.T) {
-	timer, err := NewTimer("timer_set_2", R, time.Second)
+	timer, err := NewTimer("timer_set_2", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -65,8 +65,7 @@ func TestTimer_Tick(t *testing.T) {
 }
 
 func TestBackupTimer_BeforeOldestScore(t *testing.T) {
-	timer, err := NewTimer("test_backup_before_oldest_score", R, time.Second)
-	timer.checkBackupInterval = time.Second
+	timer, err := NewTimer("test_backup_before_oldest_score", R, time.Second, time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -116,8 +115,7 @@ func TestBackupTimer_BeforeOldestScore(t *testing.T) {
 }
 
 func TestBackupTimer_EmptyReadyQueue(t *testing.T) {
-	timer, err := NewTimer("test_backup_timer_set", R, time.Second)
-	timer.checkBackupInterval = time.Second
+	timer, err := NewTimer("test_backup_timer_set", R, time.Second, time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -170,7 +168,7 @@ func BenchmarkTimer(b *testing.B) {
 	logger.SetLevel(logrus.ErrorLevel)
 	defer logger.SetLevel(logrus.DebugLevel)
 
-	t, err := NewTimer("timer_set_3", R, time.Second)
+	t, err := NewTimer("timer_set_3", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
@@ -217,7 +215,7 @@ func BenchmarkTimer_Pump(b *testing.B) {
 	b.StopTimer()
 
 	pool := NewPool(R)
-	timer, err := NewTimer("timer_set_4", R, time.Second)
+	timer, err := NewTimer("timer_set_4", R, time.Second, 600*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}


### PR DESCRIPTION
We can respawn lost jobs from backup queue after applying this PR. The internal implementation is depend on below thoughts:

Check the backup queue every 10min like the timer set pumping, then remove or respawn jobs when they are fulfilled one of below conditions:

* Job NOT found, it means the jobs was expired or ACKed, let disregard it
* Job is existing in backup queue and the ready queue is empty, which means jobs appeared in backup but it's not visible to any consumer, need to respawn into to timer set.
* Job score is older than first queue element, this condition likes the empty ready queue which means current job is NOT visible to any consumer, need to respawn into to timer set.