### PR TITLE
Integrate redis v2 with handler test

### DIFF
--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -34,7 +34,7 @@ func setup(conf *config.Config) {
 }
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest()
+	presetConfig, err := config.CreatePresetForTest("")
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -70,7 +70,7 @@ func setup(CONF *config.Config) {
 func teardown() {}
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest()
+	presetConfig, err := config.CreatePresetForTest("")
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type RedisConf struct {
 	MigrateTo string // If this is not empty, all the PUBLISH will go to that pool
 
 	MasterName string
+	Version    string
 }
 
 func (rc *RedisConf) validate() error {

--- a/config/preset.go
+++ b/config/preset.go
@@ -10,7 +10,7 @@ type PresetConfigForTest struct {
 	containers []*gnomock.Container
 }
 
-func CreatePresetForTest(pools ...string) (*PresetConfigForTest, error) {
+func CreatePresetForTest(version string, pools ...string) (*PresetConfigForTest, error) {
 	cfg := &Config{
 		Host:      "127.0.0.1",
 		Port:      7777,
@@ -27,7 +27,7 @@ func CreatePresetForTest(pools ...string) (*PresetConfigForTest, error) {
 	}
 	addr := defaultContainer.DefaultAddress()
 	cfg.AdminRedis.Addr = addr
-	cfg.Pool[DefaultPoolName] = RedisConf{Addr: addr}
+	cfg.Pool[DefaultPoolName] = RedisConf{Addr: addr, Version: version}
 
 	containers := []*gnomock.Container{defaultContainer}
 	for _, extraPool := range pools {
@@ -35,7 +35,10 @@ func CreatePresetForTest(pools ...string) (*PresetConfigForTest, error) {
 			continue
 		}
 		extraContainer, _ := gnomock.Start(p)
-		cfg.Pool[extraPool] = RedisConf{Addr: extraContainer.DefaultAddress()}
+		cfg.Pool[extraPool] = RedisConf{
+			Addr:    extraContainer.DefaultAddress(),
+			Version: version,
+		}
 		containers = append(containers, extraContainer)
 	}
 	return &PresetConfigForTest{

--- a/engine/migration/setup.go
+++ b/engine/migration/setup.go
@@ -10,8 +10,11 @@ import (
 
 var logger *logrus.Logger
 
-func Setup(conf *config.Config, l *logrus.Logger) error {
+func SetLogger(l *logrus.Logger) {
 	logger = l
+}
+
+func Setup(conf *config.Config) error {
 	for redisPool, poolConf := range conf.Pool {
 		if poolConf.MigrateTo != "" {
 			oldEngine := engine.GetEngineByKind(engine.KindRedis, redisPool)

--- a/engine/migration/setup_test.go
+++ b/engine/migration/setup_test.go
@@ -23,8 +23,8 @@ func setup(Conf *config.Config) {
 	logger = logrus.New()
 	level, _ := logrus.ParseLevel(Conf.LogLevel)
 	logger.SetLevel(level)
-
-	if err := redis.Setup(Conf, logger); err != nil {
+	redis.SetLogger(logger)
+	if err := redis.Setup(Conf); err != nil {
 		panic(fmt.Sprintf("Failed to setup redis engine: %s", err))
 	}
 	for _, poolConf := range Conf.Pool {

--- a/engine/migration/setup_test.go
+++ b/engine/migration/setup_test.go
@@ -48,7 +48,7 @@ func teardown() {
 }
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest("migrate")
+	presetConfig, err := config.CreatePresetForTest("", "migrate")
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/engine/redis/setup.go
+++ b/engine/redis/setup.go
@@ -20,9 +20,13 @@ var (
 	dummyCtx = context.TODO()
 )
 
-// Setup set the essential config of redis engine
-func Setup(conf *config.Config, l *logrus.Logger) error {
+// SetLogger will set the logger for engine
+func SetLogger(l *logrus.Logger) {
 	logger = l
+}
+
+// Setup set the essential config of redis engine
+func Setup(conf *config.Config) error {
 	for name, poolConf := range conf.Pool {
 		if len(poolConf.Version) != 0 {
 			continue

--- a/engine/redis/setup.go
+++ b/engine/redis/setup.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +24,10 @@ var (
 func Setup(conf *config.Config, l *logrus.Logger) error {
 	logger = l
 	for name, poolConf := range conf.Pool {
+		if len(poolConf.Version) != 0 {
+			continue
+		}
+
 		if poolConf.PoolSize == 0 {
 			poolConf.PoolSize = MaxRedisConnections
 		}
@@ -43,9 +46,6 @@ func Setup(conf *config.Config, l *logrus.Logger) error {
 			return fmt.Errorf("setup engine error: %s", err)
 		}
 		engine.Register(engine.KindRedis, name, e)
-	}
-	if engine.GetEngineByKind(engine.KindRedis, "") == nil {
-		return errors.New("default redis engine not found")
 	}
 	return nil
 }

--- a/engine/redis/setup_test.go
+++ b/engine/redis/setup_test.go
@@ -39,7 +39,7 @@ func setup(CONF *config.Config) {
 }
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest()
+	presetConfig, err := config.CreatePresetForTest("")
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/engine/redis_v2/hooks/init.go
+++ b/engine/redis_v2/hooks/init.go
@@ -13,7 +13,7 @@ var _metrics *performanceMetrics
 
 const (
 	_namespace = "infra"
-	_subsystem = "lmstfy_redis"
+	_subsystem = "lmstfy_redis_v2"
 )
 
 func setupMetrics() {

--- a/engine/redis_v2/metrics.go
+++ b/engine/redis_v2/metrics.go
@@ -48,7 +48,7 @@ var (
 
 const (
 	Namespace = "infra"
-	Subsystem = "lmstfy_redis"
+	Subsystem = "lmstfy_redis_v2"
 )
 
 func setupMetrics() {

--- a/engine/redis_v2/setup.go
+++ b/engine/redis_v2/setup.go
@@ -24,9 +24,13 @@ var (
 	dummyCtx = context.TODO()
 )
 
-// Setup set the essential config of redis engine
-func Setup(conf *config.Config, l *logrus.Logger) error {
+// SetLogger will set the logger for engine
+func SetLogger(l *logrus.Logger) {
 	logger = l
+}
+
+// Setup set the essential config of redis engine
+func Setup(conf *config.Config) error {
 	for name, poolConf := range conf.Pool {
 		// Only register v2 engine when the version is explicitly specified as "v2"
 		if !strings.EqualFold(poolConf.Version, VersionV2) {

--- a/engine/redis_v2/setup_test.go
+++ b/engine/redis_v2/setup_test.go
@@ -39,7 +39,7 @@ func setup(CONF *config.Config) {
 }
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest()
+	presetConfig, err := config.CreatePresetForTest(VersionV2)
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/helper/setup_test.go
+++ b/helper/setup_test.go
@@ -13,7 +13,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	presetConfig, err := config.CreatePresetForTest()
+	presetConfig, err := config.CreatePresetForTest("")
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}

--- a/server/handlers/queue_test.go
+++ b/server/handlers/queue_test.go
@@ -190,10 +190,7 @@ func TestPeekQueue(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to decode response")
 	}
-	if data.JobID != jobID {
-		t.Log(resp.Body.String())
-		t.Fatal("Mismatched job")
-	}
+	assert.Equal(t, jobID, data.JobID)
 }
 
 func TestSize(t *testing.T) {
@@ -483,7 +480,7 @@ func TestRePublish(t *testing.T) {
 	if resp.Code != http.StatusCreated {
 		t.Fatal("Failed to publish")
 	}
-	job, err := engine.GetEngineByKind(engine.KindRedis, "").Consume("ns", []string{"q16"}, 5, 2)
+	job, err := engine.GetEngine("").Consume("ns", []string{"q16"}, 5, 2)
 	if err != nil || string(job.Body()) != string(data) || job.TTL() != 10 || job.ID() == jobID {
 		t.Fatal("Failed to republish", job, err)
 	}
@@ -547,7 +544,7 @@ func TestPublishBulk(t *testing.T) {
 }
 
 func publishTestJob(ns, q string, delay, ttl uint32) (body []byte, jobID string) {
-	e := engine.GetEngineByKind(engine.KindRedis, "")
+	e := engine.GetEngine("")
 	body = make([]byte, 10)
 	if _, err := rand.Read(body); err != nil {
 		panic(err)
@@ -557,7 +554,7 @@ func publishTestJob(ns, q string, delay, ttl uint32) (body []byte, jobID string)
 }
 
 func consumeTestJob(ns, q string, ttr, timeout uint32) (body []byte, jobID string) {
-	e := engine.GetEngineByKind(engine.KindRedis, "")
+	e := engine.GetEngine("")
 	job, _ := e.Consume(ns, []string{q}, ttr, timeout)
 	if job == nil {
 		return nil, ""

--- a/server/handlers/setup.go
+++ b/server/handlers/setup.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"strconv"
+	"sync"
 
 	"github.com/bitleak/lmstfy/config"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
 
+var setupOnce sync.Once
 var _logger *logrus.Logger
 
 var (
@@ -19,8 +21,10 @@ var (
 )
 
 func Setup(l *logrus.Logger) {
-	_logger = l
-	setupMetrics()
+	setupOnce.Do(func() {
+		_logger = l
+		setupMetrics()
+	})
 }
 
 func GetHTTPLogger(c *gin.Context) *logrus.Entry {

--- a/server/main.go
+++ b/server/main.go
@@ -161,13 +161,16 @@ func postValidateConfig(ctx context.Context, conf *config.Config) error {
 }
 
 func setupEngines(conf *config.Config, l *logrus.Logger) error {
-	if err := redis_engine.Setup(conf, l); err != nil {
+	redis_engine.SetLogger(l)
+	if err := redis_engine.Setup(conf); err != nil {
 		return fmt.Errorf("%w in redis engine", err)
 	}
-	if err := redis_v2.Setup(conf, l); err != nil {
+	redis_v2.SetLogger(l)
+	if err := redis_v2.Setup(conf); err != nil {
 		return fmt.Errorf("%w in redis v2 engine", err)
 	}
-	if err := migration.Setup(conf, l); err != nil {
+	migration.SetLogger(l)
+	if err := migration.Setup(conf); err != nil {
 		return fmt.Errorf("%w in migration engine", err)
 	}
 	if engine.GetEngine(config.DefaultPoolName) == nil {

--- a/server/main.go
+++ b/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,8 +13,10 @@ import (
 
 	"github.com/bitleak/lmstfy/auth"
 	"github.com/bitleak/lmstfy/config"
+	"github.com/bitleak/lmstfy/engine"
 	"github.com/bitleak/lmstfy/engine/migration"
 	redis_engine "github.com/bitleak/lmstfy/engine/redis"
+	"github.com/bitleak/lmstfy/engine/redis_v2"
 	"github.com/bitleak/lmstfy/helper"
 	"github.com/bitleak/lmstfy/log"
 	"github.com/bitleak/lmstfy/server/handlers"
@@ -157,6 +160,22 @@ func postValidateConfig(ctx context.Context, conf *config.Config) error {
 	return nil
 }
 
+func setupEngines(conf *config.Config, l *logrus.Logger) error {
+	if err := redis_engine.Setup(conf, l); err != nil {
+		return fmt.Errorf("%w in redis engine", err)
+	}
+	if err := redis_v2.Setup(conf, l); err != nil {
+		return fmt.Errorf("%w in redis v2 engine", err)
+	}
+	if err := migration.Setup(conf, l); err != nil {
+		return fmt.Errorf("%w in migration engine", err)
+	}
+	if engine.GetEngine(config.DefaultPoolName) == nil {
+		return errors.New("missing default pool")
+	}
+	return nil
+}
+
 func main() {
 	parseFlags()
 	if Flags.ShowVersion {
@@ -181,11 +200,8 @@ func main() {
 	registerSignal(shutdown, func() {
 		log.ReopenLogs(conf.LogDir, accessLogger, errorLogger)
 	})
-	if err := redis_engine.Setup(conf, errorLogger); err != nil {
-		panic(fmt.Sprintf("Failed to setup redis engine: %s", err))
-	}
-	if err := migration.Setup(conf, errorLogger); err != nil {
-		panic(fmt.Sprintf("Failed to setup migration engine: %s", err))
+	if err := setupEngines(conf, errorLogger); err != nil {
+		panic(fmt.Sprintf("Failed to setup engines, err: %s", err.Error()))
 	}
 	if err := auth.Setup(conf); err != nil {
 		panic(fmt.Sprintf("Failed to setup auth module: %s", err))


### PR DESCRIPTION
Currently, we only runs the redis engine in handler test case, and we want to run the redis_v2 engine as well to make sure redis_v2 always works well with handler.