### PR TITLE
Fix unit test for redis V2 engine

### DIFF
--- a/datamanager/setup.go
+++ b/datamanager/setup.go
@@ -63,7 +63,7 @@ func NewDataManger(cfg *config.Config) (*DataManager, error) {
 	}, nil
 }
 
-func (m *DataManager) pumpFn(name string, pool engine.Engine) func() bool {
+func (m *DataManager) PumpFn(name string, pool engine.Engine) func() bool {
 	return func() bool {
 		now := time.Now()
 		req := &model.JobDataReq{
@@ -105,7 +105,7 @@ func (m *DataManager) AddPool(name string, pool engine.Engine) {
 	// FIXME: choose a right expiry value
 	redisLock := lock.NewRedisLock(m.redisCli, name, 10*time.Second)
 	pumper := pumper.NewDefault(redisLock, time.Minute)
-	go pumper.Loop(m.pumpFn(name, pool))
+	go pumper.Loop(m.PumpFn(name, pool))
 }
 
 func (m *DataManager) AddJob(ctx context.Context, job *model.JobData) error {

--- a/engine/redis/engine.go
+++ b/engine/redis/engine.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/bitleak/lmstfy/datamanager/storage"
-	"github.com/bitleak/lmstfy/datamanager/storage/model"
-
 	go_redis "github.com/go-redis/redis/v8"
 
 	"github.com/bitleak/lmstfy/engine"
@@ -285,22 +283,4 @@ func (e *Engine) DumpInfo(out io.Writer) error {
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "    ")
 	return enc.Encode(metadata)
-}
-
-func (e *Engine) writeJob2Storage(poolName string, job engine.Job) error {
-	now := time.Now().Unix()
-	jobs := []*model.JobData{
-		{
-			PoolName:    poolName,
-			JobID:       job.ID(),
-			Namespace:   job.Namespace(),
-			Queue:       job.Queue(),
-			Body:        job.Body(),
-			ExpiredTime: now + int64(job.TTL()),
-			ReadyTime:   now + int64(job.Delay()),
-			Tries:       int64(job.Tries()),
-			CreatedTime: now,
-		},
-	}
-	return e.storage.BatchAddJobs(dummyCtx, jobs)
 }

--- a/engine/redis/setup_test.go
+++ b/engine/redis/setup_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 var (
-	R   *RedisInstance
-	Cfg *config.PresetConfigForTest
+	R *RedisInstance
 )
 
 func setup(CONF *config.Config) {
@@ -47,7 +46,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("CreatePresetForTest failed with error: %s", err))
 	}
-	Cfg = presetConfig
 	defer presetConfig.Destroy()
 	setup(presetConfig.Config)
 	ret := m.Run()

--- a/engine/redis_v2/setup_test.go
+++ b/engine/redis_v2/setup_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var R *RedisInstance
+var (
+	R   *RedisInstance
+	Cfg *config.PresetConfigForTest
+)
 
 func setup(CONF *config.Config) {
 	logger = logrus.New()
@@ -45,6 +48,7 @@ func TestMain(m *testing.M) {
 	}
 	defer presetConfig.Destroy()
 	setup(presetConfig.Config)
+	Cfg = presetConfig
 	ret := m.Run()
 	os.Exit(ret)
 }


### PR DESCRIPTION
1. move storage test code from redis engine to redis_v2 engine.
2. fix order of data manager and engine initialization.
3. make pumpFn an exported method for more flexibility in unit test.