### PR TITLE
Optimize secondary storage interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	DefaultPoolName = "default"
+
+	minSecondaryStorageThreshold = 60 * 60
 )
 
 type Config struct {
@@ -51,7 +53,7 @@ type RedisConf struct {
 
 	// number of seconds. when job's delay second is greater than pumpStorageThresh,
 	//it will be written to storage if enabled
-	Write2StorageThresh int
+	SecondaryStorageThresholdSeconds int64
 }
 
 type SpannerConfig struct {
@@ -72,6 +74,9 @@ func (rc *RedisConf) validate() error {
 	}
 	if rc.DB < 0 {
 		return errors.New("the pool db must be greater than 0 or equal to 0")
+	}
+	if rc.EnableSecondaryStorage && rc.SecondaryStorageThresholdSeconds < minSecondaryStorageThreshold {
+		return errors.New("write to secondary storage threshold required at least 1 hour")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 const (
 	DefaultPoolName = "default"
 
-	minSecondaryStorageThreshold = 60 * 60
+	minSecondaryStorageThresholdSeconds = 60 * 60
 )
 
 type Config struct {
@@ -75,7 +75,7 @@ func (rc *RedisConf) validate() error {
 	if rc.DB < 0 {
 		return errors.New("the pool db must be greater than 0 or equal to 0")
 	}
-	if rc.EnableSecondaryStorage && rc.SecondaryStorageThresholdSeconds < minSecondaryStorageThreshold {
+	if rc.EnableSecondaryStorage && rc.SecondaryStorageThresholdSeconds < minSecondaryStorageThresholdSeconds {
 		return errors.New("write to secondary storage threshold required at least 1 hour")
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -49,8 +49,6 @@ type RedisConf struct {
 
 	EnableSecondaryStorage bool
 
-	// number of seconds which job data is pumped from storage to engine periodically
-	StoragePumpPeriod int
 	// number of seconds. when job's delay second is greater than pumpStorageThresh,
 	//it will be written to storage if enabled
 	Write2StorageThresh int
@@ -74,11 +72,6 @@ func (rc *RedisConf) validate() error {
 	}
 	if rc.DB < 0 {
 		return errors.New("the pool db must be greater than 0 or equal to 0")
-	}
-	if rc.EnableSecondaryStorage {
-		if rc.StoragePumpPeriod >= rc.Write2StorageThresh {
-			return errors.New("the pool StoragePumpPeriod must be less than Write2StorageThresh")
-		}
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,8 +22,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 
 	conf.EnableSecondaryStorage = true
-	conf.StoragePumpPeriod = 20
-	conf.Write2StorageThresh = 10
+	conf.SecondaryStorageThresholdSeconds = 10
 	if err := conf.validate(); err == nil {
 		t.Fatalf("validate addr error was expected, but got nil")
 	}

--- a/engine/redis_v2/engine.go
+++ b/engine/redis_v2/engine.go
@@ -83,7 +83,7 @@ func (e *Engine) Publish(namespace, queue string, body []byte, ttlSecond, delayS
 
 	if e.cfg.EnableSecondaryStorage &&
 		storage.Get() != nil &&
-		delaySecond > uint32(e.cfg.Write2StorageThresh) {
+		delaySecond > uint32(e.cfg.SecondaryStorageThresholdSeconds) {
 		if err := e.sink2SecondStorage(context.TODO(), job); err == nil {
 			return job.ID(), nil
 		}

--- a/engine/redis_v2/engine_test.go
+++ b/engine/redis_v2/engine_test.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	db              = "projects/test-project/instances/test-instance/databases/test-db1"
-	StoragePoolConf = &config.RedisConf{EnableSecondaryStorage: true, StoragePumpPeriod: 5, Write2StorageThresh: 10}
+	StoragePoolConf = &config.RedisConf{EnableSecondaryStorage: true, SecondaryStorageThresholdSeconds: 10}
 	PoolConf        = &config.RedisConf{}
 	SecStgConf      = &config.SpannerConfig{
 		Project:   "test-project",
@@ -81,7 +81,7 @@ func TestEngine_Publish_SecondaryStorage(t *testing.T) {
 
 	redisLock := lock.NewRedisLock(R.Conn, R.Name, 10*time.Second)
 	pumper := pumper.NewDefault(redisLock, 5*time.Second)
-	go pumper.Loop(dataMgr.PumpFn(R.Name, e))
+	go pumper.Loop(dataMgr.PumpFn(R.Name, e, 10))
 
 	// Publish long-delay job
 	body := []byte("hello msg long delay job")

--- a/engine/redis_v2/setup.go
+++ b/engine/redis_v2/setup.go
@@ -18,7 +18,8 @@ import (
 const (
 	MaxRedisConnections = 5000
 	VersionV2           = "v2"
-	maxPumpThreshold    = 24 * 60 * 60
+
+	maxPumpInThresholdSeconds = 24 * 60 * 60
 )
 
 var (
@@ -59,8 +60,8 @@ func Setup(conf *config.Config) error {
 		engine.Register(engine.KindRedisV2, name, e)
 		if poolConf.EnableSecondaryStorage && conf.HasSecondaryStorage() {
 			threshold := poolConf.SecondaryStorageThresholdSeconds / 3
-			if threshold >= maxPumpThreshold {
-				threshold = maxPumpThreshold
+			if threshold >= maxPumpInThresholdSeconds {
+				threshold = maxPumpInThresholdSeconds
 			}
 			storage.Get().AddPool(name, e, threshold)
 		}

--- a/engine/redis_v2/setup.go
+++ b/engine/redis_v2/setup.go
@@ -18,6 +18,7 @@ import (
 const (
 	MaxRedisConnections = 5000
 	VersionV2           = "v2"
+	maxPumpThreshold    = 24 * 60 * 60
 )
 
 var (
@@ -57,7 +58,11 @@ func Setup(conf *config.Config) error {
 		}
 		engine.Register(engine.KindRedisV2, name, e)
 		if poolConf.EnableSecondaryStorage && conf.HasSecondaryStorage() {
-			storage.Get().AddPool(name, e)
+			threshold := poolConf.SecondaryStorageThresholdSeconds / 3
+			if threshold >= maxPumpThreshold {
+				threshold = maxPumpThreshold
+			}
+			storage.Get().AddPool(name, e, threshold)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently, we had exposed too many configurations to users, and most of them
are never changed at all. So I think we can minimized expose configurations which
introduced by V2, then add them back if users requested.