### PR TITLE
Add new publish with job id method to keep jobid consistent for secondary storage

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -22,4 +22,5 @@ type Engine interface {
 	Shutdown()
 
 	DumpInfo(output io.Writer) error
+	PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Engine interface {
-	Publish(namespace, queue string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error)
+	Publish(job Job) (jobID string, err error)
 	Consume(namespace string, queues []string, ttrSecond, timeoutSecond uint32) (job Job, err error)
 	BatchConsume(namespace string, queues []string, count, ttrSecond, timeoutSecond uint32) (jobs []Job, err error)
 	Delete(namespace, queue, jobID string) error
@@ -22,5 +22,4 @@ type Engine interface {
 	Shutdown()
 
 	DumpInfo(output io.Writer) error
-	PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error)
 }

--- a/engine/job.go
+++ b/engine/job.go
@@ -64,6 +64,19 @@ func NewJobWithID(namespace, queue string, body []byte, ttl uint32, tries uint16
 	}
 }
 
+// NewJobWithJobID creates a job object with job ID. This case could occur when the job's source is from storage.
+func NewJobWithJobID(namespace, queue string, body []byte, ttl, delay uint32, tries uint16, jobID string) Job {
+	return &jobImpl{
+		namespace: namespace,
+		queue:     queue,
+		id:        jobID,
+		body:      body,
+		ttl:       ttl,
+		delay:     delay,
+		tries:     tries,
+	}
+}
+
 func (j *jobImpl) Namespace() string {
 	return j.namespace
 }

--- a/engine/job.go
+++ b/engine/job.go
@@ -38,21 +38,10 @@ type jobImpl struct {
 // NOTE: there is a trick in this factory, the delay is embedded in the jobID.
 // By doing this we can delete the job that's located in hourly AOF, by placing
 // a tombstone record in that AOF.
-func NewJob(namespace, queue string, body []byte, ttl, delay uint32, tries uint16) Job {
-	id := uuid.GenUniqueJobIDWithDelay(delay)
-	return &jobImpl{
-		namespace: namespace,
-		queue:     queue,
-		id:        id,
-		body:      body,
-		ttl:       ttl,
-		delay:     delay,
-		tries:     tries,
+func NewJob(namespace, queue string, body []byte, ttl, delay uint32, tries uint16, jobID string) Job {
+	if jobID == "" {
+		jobID = uuid.GenUniqueJobIDWithDelay(delay)
 	}
-}
-
-func NewJobWithID(namespace, queue string, body []byte, ttl uint32, tries uint16, jobID string) Job {
-	delay, _ := uuid.ExtractDelaySecondFromUniqueID(jobID)
 	return &jobImpl{
 		namespace: namespace,
 		queue:     queue,
@@ -64,8 +53,8 @@ func NewJobWithID(namespace, queue string, body []byte, ttl uint32, tries uint16
 	}
 }
 
-// NewJobWithJobID creates a job object with job ID. This case could occur when the job's source is from storage.
-func NewJobWithJobID(namespace, queue string, body []byte, ttl, delay uint32, tries uint16, jobID string) Job {
+func NewJobWithID(namespace, queue string, body []byte, ttl uint32, tries uint16, jobID string) Job {
+	delay, _ := uuid.ExtractDelaySecondFromUniqueID(jobID)
 	return &jobImpl{
 		namespace: namespace,
 		queue:     queue,

--- a/engine/job_test.go
+++ b/engine/job_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestJobImpl_Marshal(t *testing.T) {
-	j := NewJob("ns-1", "q-1", []byte("hello data"), 20, 10, 1)
+	j := NewJob("ns-1", "q-1", []byte("hello data"), 20, 10, 1, "")
 	bin, err := j.MarshalBinary()
 	if err != nil {
 		t.Fatal("Failed to marshal")

--- a/engine/migration/engine.go
+++ b/engine/migration/engine.go
@@ -125,3 +125,7 @@ func (e *Engine) Shutdown() {
 func (e *Engine) DumpInfo(output io.Writer) error {
 	return e.newEngine.DumpInfo(output)
 }
+
+func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
+	return e.newEngine.PublishWithJobID(namespace, queue, storedJobID, body, ttlSecond, delaySecond, tries)
+}

--- a/engine/migration/engine.go
+++ b/engine/migration/engine.go
@@ -18,8 +18,8 @@ func NewEngine(old, new engine.Engine) engine.Engine {
 	}
 }
 
-func (e *Engine) Publish(namespace, queue string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
-	return e.newEngine.Publish(namespace, queue, body, ttlSecond, delaySecond, tries)
+func (e *Engine) Publish(job engine.Job) (jobID string, err error) {
+	return e.newEngine.Publish(job)
 }
 
 // BatchConsume consume some jobs of a queue
@@ -124,8 +124,4 @@ func (e *Engine) Shutdown() {
 
 func (e *Engine) DumpInfo(output io.Writer) error {
 	return e.newEngine.DumpInfo(output)
-}
-
-func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
-	return e.newEngine.PublishWithJobID(namespace, queue, storedJobID, body, ttlSecond, delaySecond, tries)
 }

--- a/engine/migration/engine_test.go
+++ b/engine/migration/engine_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEngine_Publish(t *testing.T) {
@@ -235,12 +237,9 @@ func TestEngine_PublishWithJobID(t *testing.T) {
 	jobID, err := e.PublishWithJobID("ns-engine", "q10", "jobID1",
 		body, 10, 0, 1)
 	t.Log(jobID)
-	if err != nil {
-		t.Fatalf("Failed to publish: %s", err)
-	}
+	assert.Nil(t, err)
 	// Make sure the new engine received the job
 	job, err := NewRedisEngine.Consume("ns-engine", []string{"q10"}, 3, 0)
-	if job.ID() != jobID {
-		t.Fatalf("NewRedisEngine should received the job:%s, but get: %s", jobID, job.ID())
-	}
+	assert.Nil(t, err)
+	assert.EqualValues(t, job.ID(), jobID)
 }

--- a/engine/migration/engine_test.go
+++ b/engine/migration/engine_test.go
@@ -2,23 +2,25 @@ package migration
 
 import (
 	"bytes"
+	"github.com/bitleak/lmstfy/engine"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEngine_Publish(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 1")
-	jobID, err := e.Publish("ns-engine", "q1", body, 10, 2, 1)
+	j := engine.NewJob("ns-engine", "q1", body, 10, 2, 1, "")
+	jobID, err := e.Publish(j)
 	t.Log(jobID)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
 
 	// Publish no-delay job
-	jobID, err = e.Publish("ns-engine", "q1", body, 10, 0, 1)
+	j = engine.NewJob("ns-engine", "q1", body, 10, 0, 1, "")
+	jobID, err = e.Publish(j)
 	t.Log(jobID)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
@@ -33,7 +35,8 @@ func TestEngine_Publish(t *testing.T) {
 func TestEngine_Consume(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 2")
-	jobID, err := e.Publish("ns-engine", "q2", body, 10, 2, 1)
+	j := engine.NewJob("ns-engine", "q2", body, 10, 2, 1, "")
+	jobID, err := e.Publish(j)
 	t.Log(jobID)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
@@ -48,7 +51,8 @@ func TestEngine_Consume(t *testing.T) {
 	}
 
 	// Consume job that's published in no-delay way
-	jobID, err = e.Publish("ns-engine", "q2", body, 10, 0, 1)
+	j = engine.NewJob("ns-engine", "q2", body, 10, 0, 1, "")
+	jobID, err = e.Publish(j)
 	t.Log(jobID)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
@@ -66,8 +70,10 @@ func TestEngine_Consume(t *testing.T) {
 func TestEngine_Consume2(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 3")
-	_, err := e.Publish("ns-engine", "q3", []byte("delay msg"), 10, 5, 1)
-	jobID, err := e.Publish("ns-engine", "q3", body, 10, 2, 1)
+	j1 := engine.NewJob("ns-engine", "q3", []byte("delay msg"), 10, 5, 1, "")
+	_, err := e.Publish(j1)
+	j2 := engine.NewJob("ns-engine", "q3", body, 10, 2, 1, "")
+	jobID, err := e.Publish(j2)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
@@ -83,11 +89,13 @@ func TestEngine_Consume2(t *testing.T) {
 func TestEngine_ConsumeMulti(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 4")
-	jobID, err := e.Publish("ns-engine", "q4", body, 10, 3, 1)
+	j1 := engine.NewJob("ns-engine", "q4", body, 10, 3, 1, "")
+	jobID, err := e.Publish(j1)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
-	jobID2, err := e.Publish("ns-engine", "q5", body, 10, 1, 1)
+	j2 := engine.NewJob("ns-engine", "q5", body, 10, 1, 1, "")
+	jobID2, err := e.Publish(j2)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
@@ -112,7 +120,8 @@ func TestEngine_ConsumeMulti(t *testing.T) {
 func TestEngine_Peek(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 6")
-	jobID, err := e.Publish("ns-engine", "q6", body, 10, 0, 1)
+	j := engine.NewJob("ns-engine", "q6", body, 10, 0, 1, "")
+	jobID, err := e.Publish(j)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
@@ -125,7 +134,8 @@ func TestEngine_Peek(t *testing.T) {
 func TestEngine_DrainOld(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 7")
-	jobID, err := OldRedisEngine.Publish("ns-engine", "q7", body, 10, 0, 1)
+	j := engine.NewJob("ns-engine", "q7", body, 10, 0, 1, "")
+	jobID, err := OldRedisEngine.Publish(j)
 	job, err := e.Consume("ns-engine", []string{"q7"}, 5, 0)
 	if err != nil {
 		t.Fatal("Failed to drain the old engine's data")
@@ -138,7 +148,8 @@ func TestEngine_DrainOld(t *testing.T) {
 func TestEngine_BatchConsume(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 8")
-	jobID, err := e.Publish("ns-engine", "q8", body, 10, 2, 1)
+	j := engine.NewJob("ns-engine", "q8", body, 10, 2, 1, "")
+	jobID, err := e.Publish(j)
 	if err != nil {
 		t.Fatalf("Failed to publish: %s", err)
 	}
@@ -163,7 +174,8 @@ func TestEngine_BatchConsume(t *testing.T) {
 	// Consume some jobs
 	jobIDMap := map[string]bool{}
 	for i := 0; i < 4; i++ {
-		jobID, err := e.Publish("ns-engine", "q8", body, 10, 0, 1)
+		j := engine.NewJob("ns-engine", "q8", body, 10, 0, 1, "")
+		jobID, err := e.Publish(j)
 		t.Log(jobID)
 		if err != nil {
 			t.Fatalf("Failed to publish: %s", err)
@@ -209,7 +221,8 @@ func TestEngine_BatchConsume(t *testing.T) {
 func TestEngine_DeadLetter_Size(t *testing.T) {
 	body := []byte("hello msg 9")
 	queues := []string{"q9"}
-	jobID, err := OldRedisEngine.Publish("ns-engine", "q9", body, 10, 0, 1)
+	j := engine.NewJob("ns-engine", "q9", body, 10, 0, 1, "")
+	jobID, err := OldRedisEngine.Publish(j)
 	job, err := OldRedisEngine.Consume("ns-engine", queues, 0, 0)
 	if err != nil {
 		t.Fatal("Failed to drain the old engine's data")
@@ -217,7 +230,8 @@ func TestEngine_DeadLetter_Size(t *testing.T) {
 	if job.ID() != jobID {
 		t.Fatal("Mismatched job")
 	}
-	jobID, err = NewRedisEngine.Publish("ns-engine", "q9", body, 10, 0, 1)
+	j = engine.NewJob("ns-engine", "q9", body, 10, 0, 1, "")
+	jobID, err = NewRedisEngine.Publish(j)
 	job, err = NewRedisEngine.Consume("ns-engine", queues, 0, 0)
 	if job.ID() != jobID {
 		t.Fatal("Mismatched job")
@@ -234,8 +248,8 @@ func TestEngine_PublishWithJobID(t *testing.T) {
 	e := NewEngine(OldRedisEngine, NewRedisEngine)
 	body := []byte("hello msg 1")
 	// Publish no-delay job
-	jobID, err := e.PublishWithJobID("ns-engine", "q10", "jobID1",
-		body, 10, 0, 1)
+	j := engine.NewJob("ns-engine", "q10", body, 10, 0, 1, "jobID1")
+	jobID, err := e.Publish(j)
 	t.Log(jobID)
 	assert.Nil(t, err)
 	// Make sure the new engine received the job

--- a/engine/migration/engine_test.go
+++ b/engine/migration/engine_test.go
@@ -227,3 +227,20 @@ func TestEngine_DeadLetter_Size(t *testing.T) {
 		t.Fatalf("Expected the deadletter queue size is: %d, but got %d\n", 2, size)
 	}
 }
+
+func TestEngine_PublishWithJobID(t *testing.T) {
+	e := NewEngine(OldRedisEngine, NewRedisEngine)
+	body := []byte("hello msg 1")
+	// Publish no-delay job
+	jobID, err := e.PublishWithJobID("ns-engine", "q10", "jobID1",
+		body, 10, 0, 1)
+	t.Log(jobID)
+	if err != nil {
+		t.Fatalf("Failed to publish: %s", err)
+	}
+	// Make sure the new engine received the job
+	job, err := NewRedisEngine.Consume("ns-engine", []string{"q10"}, 3, 0)
+	if job.ID() != jobID {
+		t.Fatalf("NewRedisEngine should received the job:%s, but get: %s", jobID, job.ID())
+	}
+}

--- a/engine/redis/deadletter_test.go
+++ b/engine/redis/deadletter_test.go
@@ -57,9 +57,9 @@ func TestDeadLetter_Delete(t *testing.T) {
 
 func TestDeadLetter_Respawn(t *testing.T) {
 	p := NewPool(R)
-	job1 := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1)
-	job2 := engine.NewJob("ns-dead", "q3", []byte("2"), 60, 0, 1)
-	job3 := engine.NewJob("ns-dead", "q3", []byte("3"), 60, 0, 1)
+	job1 := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1, "")
+	job2 := engine.NewJob("ns-dead", "q3", []byte("2"), 60, 0, 1, "")
+	job3 := engine.NewJob("ns-dead", "q3", []byte("3"), 60, 0, 1, "")
 	p.Add(job1)
 	p.Add(job2)
 	p.Add(job3)
@@ -120,7 +120,7 @@ func TestDeadLetter_Size(t *testing.T) {
 	dl, _ := NewDeadLetter("ns-dead", "q3", R)
 	cnt := 3
 	for i := 0; i < cnt; i++ {
-		job := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1)
+		job := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1, "")
 		p.Add(job)
 		dl.Add(job.ID())
 	}

--- a/engine/redis/engine.go
+++ b/engine/redis/engine.go
@@ -76,28 +76,7 @@ func (e *Engine) Publish(namespace, queue string, body []byte, ttlSecond, delayS
 	e.meta.RecordIfNotExist(namespace, queue)
 	e.monitor.MonitorIfNotExist(namespace, queue)
 	job := engine.NewJob(namespace, queue, body, ttlSecond, delaySecond, tries)
-	if tries == 0 {
-		return job.ID(), nil
-	}
-
-	err = e.pool.Add(job)
-	if err != nil {
-		return job.ID(), fmt.Errorf("pool: %s", err)
-	}
-
-	if delaySecond == 0 {
-		q := NewQueue(namespace, queue, e.redis, e.timer)
-		err = q.Push(job, tries)
-		if err != nil {
-			err = fmt.Errorf("queue: %s", err)
-		}
-		return job.ID(), err
-	}
-	err = e.timer.Add(namespace, queue, job.ID(), delaySecond, tries)
-	if err != nil {
-		err = fmt.Errorf("timer: %s", err)
-	}
-	return job.ID(), err
+	return e.PublishJobs(job)
 }
 
 // BatchConsume consume some jobs of a queue
@@ -297,7 +276,11 @@ func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []b
 	e.meta.RecordIfNotExist(namespace, queue)
 	e.monitor.MonitorIfNotExist(namespace, queue)
 	job := engine.NewJobWithJobID(namespace, queue, body, ttlSecond, delaySecond, tries, storedJobID)
-	if tries == 0 {
+	return e.PublishJobs(job)
+}
+
+func (e *Engine) PublishJobs(job engine.Job) (jobID string, err error) {
+	if job.Tries() == 0 {
 		return job.ID(), nil
 	}
 
@@ -305,16 +288,15 @@ func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []b
 	if err != nil {
 		return job.ID(), fmt.Errorf("pool: %s", err)
 	}
-
-	if delaySecond == 0 {
-		q := NewQueue(namespace, queue, e.redis, e.timer)
-		err = q.Push(job, tries)
+	if job.Delay() == 0 {
+		q := NewQueue(job.Namespace(), job.Queue(), e.redis, e.timer)
+		err = q.Push(job, job.Tries())
 		if err != nil {
 			err = fmt.Errorf("queue: %s", err)
 		}
 		return job.ID(), err
 	}
-	err = e.timer.Add(namespace, queue, job.ID(), delaySecond, tries)
+	err = e.timer.Add(job.Namespace(), job.Queue(), job.ID(), job.Delay(), job.Tries())
 	if err != nil {
 		err = fmt.Errorf("timer: %s", err)
 	}

--- a/engine/redis/engine_test.go
+++ b/engine/redis/engine_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEngine_Publish(t *testing.T) {
@@ -235,20 +237,14 @@ func TestEngine_PublishWithJobID(t *testing.T) {
 	jobID1, err := e.PublishWithJobID("ns-engine", "q8", "jobID1",
 		body, 10, 0, 1)
 	t.Log(jobID1)
-	if err != nil {
-		t.Fatalf("Failed to PublishWithJobID: %s with error: %v", jobID1, err)
-	}
+	assert.Nil(t, err)
 
 	// Make sure the engine received the job
 	job, err := e.Consume("ns-engine", []string{"q8"}, 3, 0)
-	if job.ID() != jobID1 {
-		t.Fatalf("Engine should received the job:%s, but get: %s", jobID1, job.ID())
-	}
+	assert.EqualValues(t, jobID1, job.ID())
 
 	// Publish job with null job id
 	_, err = e.PublishWithJobID("ns-engine", "q8", "",
 		body, 10, 0, 1)
-	if err == nil {
-		t.Fatal("PublishWithJobID expected error of null job id, but got nil error")
-	}
+	assert.NotNil(t, err)
 }

--- a/engine/redis/engine_test.go
+++ b/engine/redis/engine_test.go
@@ -224,3 +224,31 @@ func TestEngine_BatchConsume(t *testing.T) {
 		t.Fatalf("Mistmatched jobs count")
 	}
 }
+
+func TestEngine_PublishWithJobID(t *testing.T) {
+	e, err := NewEngine(R.Name, R.Conn)
+	if err != nil {
+		panic(fmt.Sprintf("Setup engine error: %s", err))
+	}
+	defer e.Shutdown()
+	body := []byte("hello msg 1")
+	jobID1, err := e.PublishWithJobID("ns-engine", "q8", "jobID1",
+		body, 10, 0, 1)
+	t.Log(jobID1)
+	if err != nil {
+		t.Fatalf("Failed to PublishWithJobID: %s with error: %v", jobID1, err)
+	}
+
+	// Make sure the engine received the job
+	job, err := e.Consume("ns-engine", []string{"q8"}, 3, 0)
+	if job.ID() != jobID1 {
+		t.Fatalf("Engine should received the job:%s, but get: %s", jobID1, job.ID())
+	}
+
+	// Publish job with null job id
+	_, err = e.PublishWithJobID("ns-engine", "q8", "",
+		body, 10, 0, 1)
+	if err == nil {
+		t.Fatal("PublishWithJobID expected error of null job id, but got nil error")
+	}
+}

--- a/engine/redis/pool_test.go
+++ b/engine/redis/pool_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPool_Add(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-pool", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := p.Add(job); err != nil {
 		t.Errorf("Failed to add job to pool: %s", err)
 	}
@@ -20,7 +20,7 @@ func TestPool_Add(t *testing.T) {
 // Test TTL
 func TestPool_Add2(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q2", []byte("hello msg 2"), 1, 0, 1)
+	job := engine.NewJob("ns-pool", "q2", []byte("hello msg 2"), 1, 0, 1, "")
 	p.Add(job)
 	time.Sleep(2 * time.Second)
 	_, err := R.Conn.Get(dummyCtx, PoolJobKey(job)).Result()
@@ -32,7 +32,7 @@ func TestPool_Add2(t *testing.T) {
 
 func TestPool_Delete(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q3", []byte("hello msg 3"), 10, 0, 1)
+	job := engine.NewJob("ns-pool", "q3", []byte("hello msg 3"), 10, 0, 1, "")
 	p.Add(job)
 	if err := p.Delete(job.Namespace(), job.Queue(), job.ID()); err != nil {
 		t.Fatalf("Failed to delete job from pool: %s", err)
@@ -41,7 +41,7 @@ func TestPool_Delete(t *testing.T) {
 
 func TestPool_Get(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q4", []byte("hello msg 4"), 50, 0, 1)
+	job := engine.NewJob("ns-pool", "q4", []byte("hello msg 4"), 50, 0, 1, "")
 	p.Add(job)
 	body, ttl, err := p.Get(job.Namespace(), job.Queue(), job.ID())
 	if err != nil {

--- a/engine/redis/queue_test.go
+++ b/engine/redis/queue_test.go
@@ -18,12 +18,12 @@ func TestQueue_Push(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q1", R, timer)
-	job := engine.NewJob("ns-queue", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := q.Push(job, 5); err != nil {
 		t.Fatalf("Failed to push job into queue: %s", err)
 	}
 
-	job2 := engine.NewJob("ns-queue", "q2", []byte("hello msg 1"), 10, 0, 1)
+	job2 := engine.NewJob("ns-queue", "q2", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := q.Push(job2, 5); err != engine.ErrWrongQueue {
 		t.Fatalf("Expected to get wrong queue error, but got: %s", err)
 	}
@@ -36,7 +36,7 @@ func TestQueue_Poll(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q2", R, timer)
-	job := engine.NewJob("ns-queue", "q2", []byte("hello msg 2"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q2", []byte("hello msg 2"), 10, 0, 1, "")
 	go func() {
 		time.Sleep(time.Second)
 		q.Push(job, 2)
@@ -57,7 +57,7 @@ func TestQueue_Peek(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q3", R, timer)
-	job := engine.NewJob("ns-queue", "q3", []byte("hello msg 3"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q3", []byte("hello msg 3"), 10, 0, 1, "")
 	q.Push(job, 2)
 	jobID, tries, err := q.Peek()
 	if err != nil || jobID == "" || tries != 2 {
@@ -75,7 +75,7 @@ func TestQueue_Destroy(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q4", R, timer)
-	job := engine.NewJob("ns-queue", "q4", []byte("hello msg 4"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q4", []byte("hello msg 4"), 10, 0, 1, "")
 	q.Push(job, 2)
 	count, err := q.Destroy()
 	if err != nil {
@@ -100,7 +100,7 @@ func TestQueue_Tries(t *testing.T) {
 	queue := "q5"
 	q := NewQueue(namespace, queue, R, timer)
 	var maxTries uint16 = 2
-	job := engine.NewJob(namespace, queue, []byte("hello msg 5"), 30, 0, maxTries)
+	job := engine.NewJob(namespace, queue, []byte("hello msg 5"), 30, 0, maxTries, "")
 	q.Push(job, maxTries)
 	pool := NewPool(R)
 	pool.Add(job)
@@ -158,7 +158,7 @@ func TestPopMultiQueues(t *testing.T) {
 	queueName := "q7"
 	q := NewQueue(namespace, queueName, R, nil)
 	msg := "hello msg 7"
-	job := engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2)
+	job := engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2, "")
 	q.Push(job, 2)
 	gotQueueName, gotVal, err = popMultiQueues(R, queueNames)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestPopMultiQueues(t *testing.T) {
 
 	// single queue condition
 	queueName = "q8"
-	job = engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2)
+	job = engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2, "")
 	q = NewQueue(namespace, queueName, R, nil)
 	q.Push(job, 2)
 	gotQueueName, gotVal, err = popMultiQueues(R, []string{queueNames[2]})

--- a/engine/redis/timer_test.go
+++ b/engine/redis/timer_test.go
@@ -14,7 +14,7 @@ func TestTimer_Add(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
-	job := engine.NewJob("ns-timer", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-timer", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err = timer.Add(job.Namespace(), job.Queue(), job.ID(), 10, 1); err != nil {
 		t.Errorf("Failed to add job to timer: %s", err)
 	}
@@ -26,7 +26,7 @@ func TestTimer_Tick(t *testing.T) {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
 	defer timer.Shutdown()
-	job := engine.NewJob("ns-timer", "q2", []byte("hello msg 2"), 5, 0, 1)
+	job := engine.NewJob("ns-timer", "q2", []byte("hello msg 2"), 5, 0, 1, "")
 	pool := NewPool(R)
 	pool.Add(job)
 	timer.Add(job.Namespace(), job.Queue(), job.ID(), 3, 1)
@@ -80,7 +80,7 @@ func benchmarkTimer_Add(timer *Timer) func(b *testing.B) {
 	pool := NewPool(R)
 	return func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1)
+			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1, "")
 			pool.Add(job)
 			timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 		}
@@ -93,7 +93,7 @@ func benchmarkTimer_Pop(timer *Timer) func(b *testing.B) {
 		b.StopTimer()
 		pool := NewPool(R)
 		for i := 0; i < b.N; i++ {
-			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1)
+			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1, "")
 			pool.Add(job)
 			timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 		}
@@ -119,7 +119,7 @@ func BenchmarkTimer_Pump(b *testing.B) {
 	}
 	timer.Shutdown()
 	for i := 0; i < 10000; i++ {
-		job := engine.NewJob("ns-timer", "q4", []byte("hello msg 1"), 100, 0, 1)
+		job := engine.NewJob("ns-timer", "q4", []byte("hello msg 1"), 100, 0, 1, "")
 		pool.Add(job)
 		timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 	}

--- a/engine/redis_v2/deadletter_test.go
+++ b/engine/redis_v2/deadletter_test.go
@@ -57,9 +57,9 @@ func TestDeadLetter_Delete(t *testing.T) {
 
 func TestDeadLetter_Respawn(t *testing.T) {
 	p := NewPool(R)
-	job1 := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1)
-	job2 := engine.NewJob("ns-dead", "q3", []byte("2"), 60, 0, 1)
-	job3 := engine.NewJob("ns-dead", "q3", []byte("3"), 60, 0, 1)
+	job1 := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1, "")
+	job2 := engine.NewJob("ns-dead", "q3", []byte("2"), 60, 0, 1, "")
+	job3 := engine.NewJob("ns-dead", "q3", []byte("3"), 60, 0, 1, "")
 	p.Add(job1)
 	p.Add(job2)
 	p.Add(job3)
@@ -120,7 +120,7 @@ func TestDeadLetter_Size(t *testing.T) {
 	dl, _ := NewDeadLetter("ns-dead", "q3", R)
 	cnt := 3
 	for i := 0; i < cnt; i++ {
-		job := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1)
+		job := engine.NewJob("ns-dead", "q3", []byte("1"), 60, 0, 1, "")
 		p.Add(job)
 		dl.Add(job.ID())
 	}

--- a/engine/redis_v2/engine.go
+++ b/engine/redis_v2/engine.go
@@ -74,7 +74,7 @@ func (e *Engine) Publish(job engine.Job) (jobID string, err error) {
 			metrics.publishQueueJobs.WithLabelValues(e.redis.Name, job.Namespace(), job.Queue()).Inc()
 		}
 	}()
-	return e.publishJobs(job)
+	return e.publishJob(job)
 }
 
 func (e *Engine) sink2SecondStorage(ctx context.Context, job engine.Job) error {
@@ -277,7 +277,7 @@ func (e *Engine) DumpInfo(out io.Writer) error {
 	return enc.Encode(metadata)
 }
 
-func (e *Engine) publishJobs(job engine.Job) (jobID string, err error) {
+func (e *Engine) publishJob(job engine.Job) (jobID string, err error) {
 	e.meta.RecordIfNotExist(job.Namespace(), job.Queue())
 	e.monitor.MonitorIfNotExist(job.Namespace(), job.Queue())
 	if job.Tries() == 0 {

--- a/engine/redis_v2/engine.go
+++ b/engine/redis_v2/engine.go
@@ -3,7 +3,6 @@ package redis_v2
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -68,17 +67,14 @@ func NewEngine(redisName string, cfg *config.RedisConf, conn *go_redis.Client) (
 	}, nil
 }
 
-func (e *Engine) Publish(namespace, queue string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
+func (e *Engine) Publish(job engine.Job) (jobID string, err error) {
 	defer func() {
 		if err == nil {
 			metrics.publishJobs.WithLabelValues(e.redis.Name).Inc()
-			metrics.publishQueueJobs.WithLabelValues(e.redis.Name, namespace, queue).Inc()
+			metrics.publishQueueJobs.WithLabelValues(e.redis.Name, job.Namespace(), job.Queue()).Inc()
 		}
 	}()
-	e.meta.RecordIfNotExist(namespace, queue)
-	e.monitor.MonitorIfNotExist(namespace, queue)
-	job := engine.NewJob(namespace, queue, body, ttlSecond, delaySecond, tries)
-	return e.PublishJobs(job)
+	return e.publishJobs(job)
 }
 
 func (e *Engine) sink2SecondStorage(ctx context.Context, job engine.Job) error {
@@ -281,23 +277,9 @@ func (e *Engine) DumpInfo(out io.Writer) error {
 	return enc.Encode(metadata)
 }
 
-func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
-	defer func() {
-		if err == nil {
-			metrics.publishJobs.WithLabelValues(e.redis.Name).Inc()
-			metrics.publishQueueJobs.WithLabelValues(e.redis.Name, namespace, queue).Inc()
-		}
-	}()
-	if storedJobID == "" {
-		return "", errors.New("PublishWithJobID failed: null job id")
-	}
-	e.meta.RecordIfNotExist(namespace, queue)
-	e.monitor.MonitorIfNotExist(namespace, queue)
-	job := engine.NewJobWithJobID(namespace, queue, body, ttlSecond, delaySecond, tries, storedJobID)
-	return e.PublishJobs(job)
-}
-
-func (e *Engine) PublishJobs(job engine.Job) (jobID string, err error) {
+func (e *Engine) publishJobs(job engine.Job) (jobID string, err error) {
+	e.meta.RecordIfNotExist(job.Namespace(), job.Queue())
+	e.monitor.MonitorIfNotExist(job.Namespace(), job.Queue())
 	if job.Tries() == 0 {
 		return job.ID(), nil
 	}

--- a/engine/redis_v2/engine.go
+++ b/engine/redis_v2/engine.go
@@ -3,6 +3,7 @@ package redis_v2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -306,4 +307,48 @@ func (e *Engine) DumpInfo(out io.Writer) error {
 	enc := json.NewEncoder(out)
 	enc.SetIndent("", "    ")
 	return enc.Encode(metadata)
+}
+
+func (e *Engine) PublishWithJobID(namespace, queue, storedJobID string, body []byte, ttlSecond, delaySecond uint32, tries uint16) (jobID string, err error) {
+	defer func() {
+		if err == nil {
+			metrics.publishJobs.WithLabelValues(e.redis.Name).Inc()
+			metrics.publishQueueJobs.WithLabelValues(e.redis.Name, namespace, queue).Inc()
+		}
+	}()
+	if storedJobID == "" {
+		return "", errors.New("PublishWithJobID failed: null job id")
+	}
+	e.meta.RecordIfNotExist(namespace, queue)
+	e.monitor.MonitorIfNotExist(namespace, queue)
+	job := engine.NewJobWithJobID(namespace, queue, body, ttlSecond, delaySecond, tries, storedJobID)
+	if tries == 0 {
+		return job.ID(), nil
+	}
+
+	if e.cfg.EnableSecondaryStorage &&
+		storage.Get() != nil &&
+		delaySecond > uint32(e.cfg.SecondaryStorageThresholdSeconds) {
+		if err := e.sink2SecondStorage(context.TODO(), job); err == nil {
+			return job.ID(), nil
+		}
+	}
+	err = e.pool.Add(job)
+	if err != nil {
+		return job.ID(), fmt.Errorf("pool: %s", err)
+	}
+
+	if delaySecond == 0 {
+		q := NewQueue(namespace, queue, e.redis, e.timer)
+		err = q.Push(job)
+		if err != nil {
+			err = fmt.Errorf("queue: %s", err)
+		}
+		return job.ID(), err
+	}
+	err = e.timer.Add(namespace, queue, job.ID(), delaySecond, tries)
+	if err != nil {
+		err = fmt.Errorf("timer: %s", err)
+	}
+	return job.ID(), err
 }

--- a/engine/redis_v2/engine_test.go
+++ b/engine/redis_v2/engine_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/bitleak/lmstfy/config"
 	"github.com/bitleak/lmstfy/storage"
 	"github.com/bitleak/lmstfy/storage/lock"
@@ -87,20 +89,14 @@ func TestEngine_Publish_SecondaryStorage(t *testing.T) {
 	body := []byte("hello msg long delay job")
 	jobID, err := e.Publish("ns-engine", "qs", body, 120, 15, 1)
 	t.Log(jobID)
-	if err != nil {
-		t.Fatalf("Failed to publish: %s", err)
-	}
-
+	assert.Nil(t, err)
 	//wait for data mgr to pump job from secondary storage to engine
 	time.Sleep(20 * time.Second)
 
 	job, err := e.Consume("ns-engine", []string{"qs"}, 3, 0)
-	if err != nil {
-		t.Fatalf("Failed to consume job from secondary storage: %s", err)
-	}
-	if jobID != job.ID() || !bytes.Equal(body, job.Body()) {
-		t.Fatalf("Mistmatched job data")
-	}
+	assert.Nil(t, err)
+	assert.EqualValues(t, jobID, job.ID())
+	assert.EqualValues(t, body, job.Body())
 }
 
 func TestEngine_Consume(t *testing.T) {
@@ -310,20 +306,14 @@ func TestEngine_PublishWithJobID(t *testing.T) {
 	jobID1, err := e.PublishWithJobID("ns-engine", "q8", "jobID1",
 		body, 10, 0, 1)
 	t.Log(jobID1)
-	if err != nil {
-		t.Fatalf("Failed to PublishWithJobID: %s with error: %v", jobID1, err)
-	}
+	assert.Nil(t, err)
 
 	// Make sure the engine received the job
 	job, err := e.Consume("ns-engine", []string{"q8"}, 3, 0)
-	if job.ID() != jobID1 {
-		t.Fatalf("Engine should received the job:%s, but get: %s", jobID1, job.ID())
-	}
+	assert.EqualValues(t, jobID1, job.ID())
 
 	// Publish job with null job id
 	_, err = e.PublishWithJobID("ns-engine", "q8", "",
 		body, 10, 0, 1)
-	if err == nil {
-		t.Fatal("PublishWithJobID expected error of null job id, but got nil error")
-	}
+	assert.NotNil(t, err)
 }

--- a/engine/redis_v2/pool_test.go
+++ b/engine/redis_v2/pool_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPool_Add(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-pool", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := p.Add(job); err != nil {
 		t.Errorf("Failed to add job to pool: %s", err)
 	}
@@ -20,7 +20,7 @@ func TestPool_Add(t *testing.T) {
 // Test TTL
 func TestPool_Add2(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q2", []byte("hello msg 2"), 1, 0, 1)
+	job := engine.NewJob("ns-pool", "q2", []byte("hello msg 2"), 1, 0, 1, "")
 	p.Add(job)
 	time.Sleep(2 * time.Second)
 	_, err := R.Conn.Get(dummyCtx, PoolJobKey(job)).Result()
@@ -32,7 +32,7 @@ func TestPool_Add2(t *testing.T) {
 
 func TestPool_Delete(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q3", []byte("hello msg 3"), 10, 0, 1)
+	job := engine.NewJob("ns-pool", "q3", []byte("hello msg 3"), 10, 0, 1, "")
 	p.Add(job)
 	if err := p.Delete(job.Namespace(), job.Queue(), job.ID()); err != nil {
 		t.Fatalf("Failed to delete job from pool: %s", err)
@@ -41,7 +41,7 @@ func TestPool_Delete(t *testing.T) {
 
 func TestPool_Get(t *testing.T) {
 	p := NewPool(R)
-	job := engine.NewJob("ns-pool", "q4", []byte("hello msg 4"), 50, 0, 1)
+	job := engine.NewJob("ns-pool", "q4", []byte("hello msg 4"), 50, 0, 1, "")
 	p.Add(job)
 	body, ttl, err := p.Get(job.Namespace(), job.Queue(), job.ID())
 	if err != nil {

--- a/engine/redis_v2/queue_test.go
+++ b/engine/redis_v2/queue_test.go
@@ -18,12 +18,12 @@ func TestQueue_Push(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q1", R, timer)
-	job := engine.NewJob("ns-queue", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := q.Push(job); err != nil {
 		t.Fatalf("Failed to push job into queue: %s", err)
 	}
 
-	job2 := engine.NewJob("ns-queue", "q2", []byte("hello msg 1"), 10, 0, 1)
+	job2 := engine.NewJob("ns-queue", "q2", []byte("hello msg 1"), 10, 0, 1, "")
 	if err := q.Push(job2); err != engine.ErrWrongQueue {
 		t.Fatalf("Expected to get wrong queue error, but got: %s", err)
 	}
@@ -36,7 +36,7 @@ func TestQueue_Poll(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q2", R, timer)
-	job := engine.NewJob("ns-queue", "q2", []byte("hello msg 2"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q2", []byte("hello msg 2"), 10, 0, 1, "")
 	go func() {
 		time.Sleep(time.Second)
 		q.Push(job)
@@ -57,7 +57,7 @@ func TestQueue_Peek(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q3", R, timer)
-	job := engine.NewJob("ns-queue", "q3", []byte("hello msg 3"), 10, 0, 2)
+	job := engine.NewJob("ns-queue", "q3", []byte("hello msg 3"), 10, 0, 2, "")
 	q.Push(job)
 	jobID, tries, err := q.Peek()
 	if err != nil || jobID == "" || tries != 2 {
@@ -75,7 +75,7 @@ func TestQueue_Destroy(t *testing.T) {
 	}
 	defer timer.Shutdown()
 	q := NewQueue("ns-queue", "q4", R, timer)
-	job := engine.NewJob("ns-queue", "q4", []byte("hello msg 4"), 10, 0, 1)
+	job := engine.NewJob("ns-queue", "q4", []byte("hello msg 4"), 10, 0, 1, "")
 	q.Push(job)
 	count, err := q.Destroy()
 	if err != nil {
@@ -100,7 +100,7 @@ func TestQueue_Tries(t *testing.T) {
 	queue := "q5"
 	q := NewQueue(namespace, queue, R, timer)
 	var maxTries uint16 = 2
-	job := engine.NewJob(namespace, queue, []byte("hello msg 5"), 30, 0, maxTries)
+	job := engine.NewJob(namespace, queue, []byte("hello msg 5"), 30, 0, maxTries, "")
 	q.Push(job)
 	pool := NewPool(R)
 	pool.Add(job)
@@ -164,7 +164,7 @@ func TestPopMultiQueues(t *testing.T) {
 	queueName := "q7"
 	q := NewQueue(namespace, queueName, R, timer)
 	msg := "hello msg 7"
-	job := engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2)
+	job := engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2, "")
 	q.Push(job)
 	gotQueueName, gotVal, err = popMultiQueues(R, queueNames)
 	if err != nil {
@@ -176,7 +176,7 @@ func TestPopMultiQueues(t *testing.T) {
 
 	// single queue condition
 	queueName = "q8"
-	job = engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2)
+	job = engine.NewJob(namespace, queueName, []byte(msg), 30, 0, 2, "")
 	q = NewQueue(namespace, queueName, R, timer)
 	q.Push(job)
 	gotQueueName, gotVal, err = popMultiQueues(R, []string{queueNames[2]})
@@ -204,7 +204,7 @@ func TestQueue_Backup(t *testing.T) {
 		if i%2 == 0 {
 			delay = 1
 		}
-		job := engine.NewJob(namespace, queue, []byte("hello msg"), 30, delay, 2)
+		job := engine.NewJob(namespace, queue, []byte("hello msg"), 30, delay, 2, "")
 		q.Push(job)
 		pool := NewPool(R)
 		pool.Add(job)

--- a/engine/redis_v2/timer_test.go
+++ b/engine/redis_v2/timer_test.go
@@ -17,7 +17,7 @@ func TestTimer_Add(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
-	job := engine.NewJob("ns-timer", "q1", []byte("hello msg 1"), 10, 0, 1)
+	job := engine.NewJob("ns-timer", "q1", []byte("hello msg 1"), 10, 0, 1, "")
 	if err = timer.Add(job.Namespace(), job.Queue(), job.ID(), 10, 1); err != nil {
 		t.Errorf("Failed to add job to timer: %s", err)
 	}
@@ -29,7 +29,7 @@ func TestTimer_Tick(t *testing.T) {
 		panic(fmt.Sprintf("Failed to new timer: %s", err))
 	}
 	defer timer.Shutdown()
-	job := engine.NewJob("ns-timer", "q2", []byte("hello msg 2"), 5, 0, 1)
+	job := engine.NewJob("ns-timer", "q2", []byte("hello msg 2"), 5, 0, 1, "")
 	pool := NewPool(R)
 	pool.Add(job)
 	timer.Add(job.Namespace(), job.Queue(), job.ID(), 3, 1)
@@ -77,7 +77,7 @@ func TestBackupTimer_BeforeOldestScore(t *testing.T) {
 	queue := NewQueue(ns, queueName, R, timer)
 	count := 10
 	for i := 0; i < count; i++ {
-		job := engine.NewJob(ns, queueName, []byte("hello msg"+strconv.Itoa(i)), 100, 1, 3)
+		job := engine.NewJob(ns, queueName, []byte("hello msg"+strconv.Itoa(i)), 100, 1, 3, "")
 		pool.Add(job)
 		if i%2 == 0 {
 			queue.Push(job)
@@ -127,7 +127,7 @@ func TestBackupTimer_EmptyReadyQueue(t *testing.T) {
 	queue := NewQueue(ns, queueName, R, timer)
 	count := 10
 	for i := 0; i < count; i++ {
-		job := engine.NewJob(ns, queueName, []byte("hello msg"+strconv.Itoa(i)), 100, 1, 3)
+		job := engine.NewJob(ns, queueName, []byte("hello msg"+strconv.Itoa(i)), 100, 1, 3, "")
 		pool.Add(job)
 		if i%2 == 0 {
 			queue.Push(job)
@@ -182,7 +182,7 @@ func benchmarkTimer_Add(timer *Timer) func(b *testing.B) {
 	pool := NewPool(R)
 	return func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1)
+			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1, "")
 			pool.Add(job)
 			timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 		}
@@ -195,7 +195,7 @@ func benchmarkTimer_Pop(timer *Timer) func(b *testing.B) {
 		b.StopTimer()
 		pool := NewPool(R)
 		for i := 0; i < b.N; i++ {
-			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1)
+			job := engine.NewJob("ns-timer", "q3", []byte("hello msg 1"), 100, 0, 1, "")
 			pool.Add(job)
 			timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 		}
@@ -221,7 +221,7 @@ func BenchmarkTimer_Pump(b *testing.B) {
 	}
 	timer.Shutdown()
 	for i := 0; i < 10000; i++ {
-		job := engine.NewJob("ns-timer", "q4", []byte("hello msg 1"), 100, 0, 1)
+		job := engine.NewJob("ns-timer", "q4", []byte("hello msg 1"), 100, 0, 1, "")
 		pool.Add(job)
 		timer.Add(job.Namespace(), job.Queue(), job.ID(), 1, 1)
 	}

--- a/server/handlers/queue.go
+++ b/server/handlers/queue.go
@@ -84,7 +84,8 @@ func Publish(c *gin.Context) {
 		return
 	}
 
-	jobID, err = e.Publish(namespace, queue, body, uint32(ttlSecond), uint32(delaySecond), uint16(tries))
+	job := engine.NewJob(namespace, queue, body, uint32(ttlSecond), uint32(delaySecond), uint16(tries), "")
+	jobID, err = e.Publish(job)
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"err":       err,
@@ -179,7 +180,8 @@ func PublishBulk(c *gin.Context) {
 
 	jobIDs := make([]string, 0)
 	for _, job := range jobs {
-		jobID, err := e.Publish(namespace, queue, job, uint32(ttlSecond), uint32(delaySecond), uint16(tries))
+		j := engine.NewJob(namespace, queue, job, uint32(ttlSecond), uint32(delaySecond), uint16(tries), "")
+		jobID, err := e.Publish(j)
 		if err != nil {
 			logger.WithFields(logrus.Fields{
 				"err":       err,

--- a/server/handlers/queue_test.go
+++ b/server/handlers/queue_test.go
@@ -549,7 +549,8 @@ func publishTestJob(ns, q string, delay, ttl uint32) (body []byte, jobID string)
 	if _, err := rand.Read(body); err != nil {
 		panic(err)
 	}
-	jobID, _ = e.Publish(ns, q, body, ttl, delay, 1)
+	j := engine.NewJob(ns, q, body, ttl, delay, 1, "")
+	jobID, _ = e.Publish(j)
 	return body, jobID
 }
 

--- a/storage/manager.go
+++ b/storage/manager.go
@@ -82,10 +82,10 @@ func (m *Manager) PumpFn(name string, pool engine.Engine, threshold int64) func(
 		}
 		jobsID := make([]string, 0)
 		for _, j := range jobs {
-			_, err := pool.Publish(j.Namespace, j.Queue, j.Body, uint32(j.ExpiredTime),
+			_, err := pool.PublishWithJobID(j.Namespace, j.Queue, j.JobID, j.Body, uint32(j.ExpiredTime),
 				uint32(j.ReadyTime-now.Unix()), uint16(j.Tries))
 			if err != nil {
-				logrus.Errorf("publish job:%v with error %v", j.JobID, err)
+				logrus.Errorf("PublishWithJobID:%v failed with error %v", j.JobID, err)
 				return false
 			}
 			jobsID = append(jobsID, j.JobID)
@@ -95,7 +95,6 @@ func (m *Manager) PumpFn(name string, pool engine.Engine, threshold int64) func(
 			logrus.Errorf("LoopPump delete jobs failed:%v", err)
 			return false
 		}
-
 		return len(jobsID) == maxJobBatchSize
 	}
 }

--- a/storage/manager.go
+++ b/storage/manager.go
@@ -81,14 +81,15 @@ func (m *Manager) PumpFn(name string, pool engine.Engine, threshold int64) func(
 			return false
 		}
 		jobsID := make([]string, 0)
-		for _, j := range jobs {
-			_, err := pool.PublishWithJobID(j.Namespace, j.Queue, j.JobID, j.Body, uint32(j.ExpiredTime),
-				uint32(j.ReadyTime-now.Unix()), uint16(j.Tries))
+		for _, job := range jobs {
+			j := engine.NewJob(job.Namespace, job.Queue, job.Body, uint32(job.ExpiredTime),
+				uint32(job.ReadyTime-now.Unix()), uint16(job.Tries), job.JobID)
+			_, err := pool.Publish(j)
 			if err != nil {
-				logrus.Errorf("PublishWithJobID:%v failed with error %v", j.JobID, err)
+				logrus.Errorf("Publish:%v failed with error %v", job.JobID, err)
 				return false
 			}
-			jobsID = append(jobsID, j.JobID)
+			jobsID = append(jobsID, job.JobID)
 		}
 
 		if _, err := m.storage.DelJobs(ctx, jobsID); err != nil {


### PR DESCRIPTION
#168 
1. add PublishWithJobID method to engine in order to keep  job id consistent when secondary storage is enabled.
2. add related unit tests.