### PR TITLE
Update storage pumper redis usage watermark

### DIFF
--- a/storage/manager.go
+++ b/storage/manager.go
@@ -31,7 +31,7 @@ const (
 	addJobSuccessStatus = "success"
 	addJobFailedStatus  = "failed"
 
-	redisMemoryUsageWatermark = 0.6 //  used_memory / max_memory
+	redisMemoryUsageWatermark = 0.8 //  used_memory / max_memory
 )
 
 type Manager struct {


### PR DESCRIPTION
When storage pumper pumps ready job from database to redis, it will check the current redis usage.
If the usage is above the threshold(previously set to 60%), the pumper will stop pumping jobs to redis.
This PR adjust that threshold from 60% to 80% based on real-life scenario, for 80% can be regarded as a relatively safe base line. 