### PR TITLE
Fix return wrong TTL when pumping job from the secondary storage  

### DIFF
--- a/storage/persistence/model/job.go
+++ b/storage/persistence/model/job.go
@@ -12,6 +12,13 @@ type DBJob struct {
 	CreatedTime int64  `spanner:"created_time" json:"created_time"`
 }
 
+func (j *DBJob) TTL(now int64) int64 {
+	if j.ExpiredTime == 0 {
+		return 0
+	}
+	return j.ExpiredTime - now
+}
+
 type DBJobReq struct {
 	PoolName  string
 	Namespace string

--- a/storage/persistence/spanner/spanner_test.go
+++ b/storage/persistence/spanner/spanner_test.go
@@ -3,115 +3,108 @@ package spanner
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
+	"time"
 
 	"github.com/bitleak/lmstfy/config"
+	"github.com/bitleak/lmstfy/engine"
+	"github.com/bitleak/lmstfy/storage/persistence/model"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-var (
-	dummyCtx = context.TODO()
+const (
+	poolName  = "test_pool"
+	namespace = "test_ns"
 )
 
-func init() {
-	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
-		panic(fmt.Sprintf("failed to find $SPANNER_EMULATOR_HOST value"))
+func TestSpanner_Basic(t *testing.T) {
+	ctx := context.Background()
+	mgr, err := NewSpanner(config.SpannerEmulator)
+	require.NoError(t, err)
+
+	jobCnt := int64(10)
+	jobIDs := make([]string, jobCnt)
+	createJobs := make([]engine.Job, jobCnt)
+	for i := int64(0); i < jobCnt; i++ {
+		queue := "q1"
+		if i%2 == 0 {
+			queue = "q2"
+		}
+		createJobs[i] = engine.NewJob(namespace, queue, []byte("hello"), 10, 4, 3, "")
+		jobIDs[i] = createJobs[i].ID()
 	}
-	err := CreateInstance(dummyCtx, config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("create instance error: %v", err))
+	require.NoError(t, mgr.BatchAddJobs(ctx, poolName, createJobs))
+
+	validateJob := func(t *testing.T, job engine.Job) {
+		assert.NotEmpty(t, job.ID())
+		assert.EqualValues(t, job.Namespace(), namespace)
+		assert.EqualValues(t, job.Tries(), 3)
+		assert.GreaterOrEqual(t, job.Delay(), uint32(1))
+		assert.LessOrEqual(t, job.Delay(), uint32(4))
+		assert.GreaterOrEqual(t, job.TTL(), uint32(1))
+		assert.LessOrEqual(t, job.TTL(), uint32(10))
 	}
-	err = CreateDatabase(dummyCtx, config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("create db error: %v", err))
-	}
+
+	t.Run("Batch Get Jobs By ID", func(t *testing.T) {
+		jobs, err := mgr.BatchGetJobsByID(ctx, jobIDs)
+		assert.Nil(t, err)
+		assert.EqualValues(t, len(jobIDs), len(jobs))
+		for _, job := range jobs {
+			validateJob(t, job)
+		}
+	})
+
+	t.Run("Get Ready Jobs", func(t *testing.T) {
+		readyJobs, err := mgr.GetReadyJobs(ctx, &model.DBJobReq{
+			PoolName:  poolName,
+			ReadyTime: time.Now().Unix() + 10,
+			Count:     jobCnt,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, jobCnt, len(readyJobs))
+		for _, job := range readyJobs {
+			validateJob(t, job)
+		}
+	})
+
+	t.Run("Get Queue Size", func(t *testing.T) {
+		queueSizes, err := mgr.GetQueueSize(ctx, []*model.DBJobReq{
+			{PoolName: poolName, Namespace: namespace, Queue: "q1", ReadyTime: time.Now().Unix() - 10, Count: jobCnt},
+			{PoolName: poolName, Namespace: namespace, Queue: "q2", ReadyTime: time.Now().Unix() - 10, Count: jobCnt},
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, jobCnt/2, queueSizes[fmt.Sprintf("%s/%s", namespace, "q1")])
+		assert.EqualValues(t, jobCnt/2, queueSizes[fmt.Sprintf("%s/%s", namespace, "q2")])
+	})
+
+	t.Run("Del Jobs", func(t *testing.T) {
+		count, err := mgr.DelJobs(context.Background(), jobIDs)
+		require.NoError(t, err)
+		require.EqualValues(t, jobCnt, count)
+	})
 }
 
-func TestCreateSpannerClient(t *testing.T) {
-	_, err := createSpannerClient(config.SpannerEmulator)
+func TestSpanner_NoExpiredJob(t *testing.T) {
+	ctx := context.Background()
+	mgr, err := NewSpanner(config.SpannerEmulator)
+	require.NoError(t, err)
+
+	jobCnt := int64(10)
+	jobIDs := make([]string, jobCnt)
+	createJobs := make([]engine.Job, jobCnt)
+	for i := int64(0); i < jobCnt; i++ {
+		queue := "q3"
+		createJobs[i] = engine.NewJob(namespace, queue, []byte("hello"), 0, 4, 3, "")
+		jobIDs[i] = createJobs[i].ID()
+	}
+	require.NoError(t, mgr.BatchAddJobs(ctx, poolName, createJobs))
+
+	jobs, err := mgr.BatchGetJobsByID(ctx, jobIDs)
 	assert.Nil(t, err)
-}
-
-func TestSpanner_BatchAddDelJobs(t *testing.T) {
-	mgr, err := NewSpanner(config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create spanner client with error: %s", err))
+	assert.EqualValues(t, len(jobIDs), len(jobs))
+	for _, job := range jobs {
+		assert.EqualValues(t, job.TTL(), 0)
 	}
-	jobs := createTestJobsData()
-	err = mgr.BatchAddJobs(ctx, poolName, jobs)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to add jobs with error: %s", err))
-	}
-	t.Logf("add jobs success %v rows", len(jobs))
-
-	count, err := mgr.DelJobs(ctx, jobIDs)
-	if err != nil {
-		panic(fmt.Sprintf("failed to delete job: %v", err))
-	}
-	t.Logf("del jobs success %v rows", count)
-}
-
-func TestSpanner_BatchGetJobs(t *testing.T) {
-	mgr, err := NewSpanner(config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create spanner client with error: %s", err))
-	}
-	jobs := createTestJobsData()
-	mgr.BatchAddJobs(ctx, poolName, jobs)
-	req := createTestReqData()
-	jobs, err = mgr.BatchGetJobs(ctx, req)
-	if err != nil {
-		panic(fmt.Sprintf("BatchGetJobs failed with error: %s", err))
-	}
-	assert.EqualValues(t, 3, len(jobs))
-	mgr.DelJobs(ctx, jobIDs)
-}
-
-func TestSpanner_GetQueueSize(t *testing.T) {
-	mgr, err := NewSpanner(config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create spanner client with error: %s", err))
-	}
-	jobs := createTestJobsData()
-	mgr.BatchAddJobs(ctx, poolName, jobs)
-	req := createTestReqData()
-	count, err := mgr.GetQueueSize(ctx, req)
-	if err != nil || len(count) == 0 {
-		panic(fmt.Sprintf("BatchGetJobs failed with error: %s", err))
-	}
-	key1, key2 := fmt.Sprintf("%s/%s", "n1", "q1"), fmt.Sprintf("%s/%s", "n1", "q2")
-	assert.EqualValues(t, 2, count[key1])
-	assert.EqualValues(t, 1, count[key2])
-	mgr.DelJobs(ctx, jobIDs)
-}
-
-func TestSpanner_GetReadyJobs(t *testing.T) {
-	mgr, err := NewSpanner(config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create spanner client with error: %s", err))
-	}
-	jobs := createTestJobsData()
-	mgr.BatchAddJobs(ctx, poolName, jobs)
-	req := createTestReqData2()
-	jobs, err = mgr.GetReadyJobs(ctx, req)
-	if err != nil {
-		panic(fmt.Sprintf("GetReadyJobs failed with error: %s", err))
-	}
-	assert.EqualValues(t, 2, len(jobs))
-	mgr.DelJobs(ctx, jobIDs)
-}
-
-func TestSpanner_BatchGetJobsByID(t *testing.T) {
-	mgr, err := NewSpanner(config.SpannerEmulator)
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create spanner client with error: %s", err))
-	}
-	jobs := createTestJobsData()
-	mgr.BatchAddJobs(ctx, poolName, jobs)
-	IDs := []string{"1", "2", "3"}
-	jobs, err = mgr.BatchGetJobsByID(ctx, IDs)
-	assert.Nil(t, err)
-	assert.EqualValues(t, 3, len(jobs))
-	mgr.DelJobs(ctx, jobIDs)
 }

--- a/storage/persitence.go
+++ b/storage/persitence.go
@@ -11,8 +11,6 @@ import (
 type Persistence interface {
 	// BatchAddJobs write jobs data into secondary storage
 	BatchAddJobs(ctx context.Context, poolName string, jobs []engine.Job) (err error)
-	// BatchGetJobs pumps data that are due before certain due time
-	BatchGetJobs(ctx context.Context, req []*model.DBJobReq) (jobs []engine.Job, err error)
 	// GetQueueSize returns the size of data in storage which are due before certain due time
 	GetQueueSize(ctx context.Context, req []*model.DBJobReq) (count map[string]int64, err error)
 	// DelJobs remove job data from storage based on job id


### PR DESCRIPTION
Currently, we put now() + TTL as the expired time when storing jobs in the database,
but didn't remove the now() after pumping jobs. This PR also removes
the unused function `BatchGetJobs` which is similar to GetReadyJobs.
