### PR TITLE
Add support of publish/consume with job attributes in client side

### DIFF
--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -53,7 +53,7 @@ func setup(CONF *config.Config) {
 	if resp.StatusCode != http.StatusCreated {
 		panic("Failed to create testing token")
 	}
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic("Failed to create testing token")
 	}


### PR DESCRIPTION
This PR introduces the new API: `PublishJob` and `RePublishJob` to allow
the use of the job attributes and mark the old API as deprecated. But we
don't add the new API for the batch publish since we think it's not a rigorous
implementation and don't encourage users to use that.